### PR TITLE
In Active Account Fix

### DIFF
--- a/includes/class-bytenft-onramp-payment-gateway.php
+++ b/includes/class-bytenft-onramp-payment-gateway.php
@@ -83,6 +83,13 @@ class BYTENFT_ONRAMP_PAYMENT_GATEWAY extends WC_Payment_Gateway_CC
 		return $this->base_url . $endpoint;
 	}
 
+	protected function log_info($message, $context = []) {
+	    wc_get_logger()->info($message, array_merge([
+	        'source' => 'bytenft-onramp-payment-gateway',
+	        'context' => $context,
+	    ]));
+	}
+
 	public function bytenft_onramp_process_admin_options()
 	{
 		parent::process_admin_options();
@@ -1097,11 +1104,68 @@ class BYTENFT_ONRAMP_PAYMENT_GATEWAY extends WC_Payment_Gateway_CC
 		]);
 	}
 
+	public function get_updated_account() {
+		$accounts = get_option('woocommerce_bytenft_payment_gateway_accounts', []);
+		$valid_accounts = [];
+		foreach ($accounts as $index => $account) {
+		    $useSandbox = $this->sandbox;
+		    $secretKey = $useSandbox ? $account['sandbox_secret_key'] : $account['live_secret_key'];
+		    $publicKey = $useSandbox ? $account['sandbox_public_key'] : $account['live_public_key'];
+
+		    $this->log_info("Checking merchant status for account #$index", [
+		        'context' => compact('useSandbox', 'publicKey')
+		    ]);
+
+		    $checkStatusUrl = $this->get_api_url('/api/check-merchant-status', $useSandbox);
+
+		    $response = wp_remote_post($checkStatusUrl, [
+		        'headers' => [
+		            'Authorization' => 'Bearer ' . $publicKey,
+		            'Content-Type'  => 'application/json',
+		        ],
+		        'timeout' => 10,
+		        'body' => wp_json_encode([
+		            'api_secret_key' => $secretKey,
+		            'is_sandbox'     => $useSandbox,
+		        ]),
+		    ]);
+
+		    $body = json_decode(wp_remote_retrieve_body($response), true);
+			$hasError = is_array($body) && strtolower($body['status'] ?? '') === 'error';
+	
+			$valid_accounts[$index] = [
+				'title' => $account['title'],
+				'priority' => $account['priority'],
+				'live_public_key' => $account['live_public_key'],
+				'live_secret_key' => $account['live_secret_key'],
+				'sandbox_public_key' => $account['sandbox_public_key'],
+				'sandbox_secret_key' => $account['sandbox_secret_key'],
+				'has_sandbox' => $account['has_sandbox'],
+				'sandbox_status' => $hasError ? 'Inactive' : 'Active',
+				'live_status' => $hasError ? 'Inactive' : 'Active',
+			];
+			$index++;
+		    $this->log_info("Account #$index not active", ['context' => $body]);
+		}
+
+		if (!empty($valid_accounts)) {
+			update_option('woocommerce_bytenft_payment_gateway_accounts', $valid_accounts);
+		}
+
+	    $this->log_info('No active account. Removing bytenft gateway.');
+	    return false;
+	}
+
 	public function hide_custom_payment_gateway_conditionally($available_gateways)
 	{
 	    $gateway_id = $this->id;
 
 	    if (!is_checkout()) {
+	        return $available_gateways;
+	    }
+
+		if (is_admin()) {
+			$this->get_updated_account();
 	        return $available_gateways;
 	    }
 


### PR DESCRIPTION
If the API keys are correct but the account is inactive, then the corresponding WordPress account is also set to inactive.
